### PR TITLE
Dockerized gmusicproxy daemon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:2.7
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY . /usr/src/app
+RUN pip install --no-cache-dir -r requirements.txt
+
+VOLUME ["/root/.config"]
+EXPOSE 9999/tcp
+ENTRYPOINT ["GMusicProxy"]


### PR DESCRIPTION
This adds a Dockerfile to have the gmusicproxy running on a docker server. The configuration file can be created in a directory and then mounted into `/root/.config` and the default listening port `9999` is exposed.