### PR TITLE
Add keyring support.

### DIFF
--- a/GMusicProxy
+++ b/GMusicProxy
@@ -31,6 +31,10 @@ import gmusicapi, gmusicapi.utils, eyed3.id3
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 from SocketServer import ThreadingMixIn
 from gmusicapi.exceptions import CallFailure
+try:
+    import keyring.core as keyring
+except ImportError:
+    pass
 
 class MultiThreadedHTTPServer(ThreadingMixIn, BaseHTTPServer.HTTPServer):
     daemon_threads = True
@@ -564,6 +568,10 @@ def getOptions(filename):
     parser.add_argument('-x', '--extended-m3u', default=False, action='store_true', help='enable non-standard extended m3u headers')
     parser.add_argument('-s', '--shoutcast-metadata', default=False, action='store_true', help='enable Shoutcast metadata protocol support (disabling IDv3 tags)')
     parser.add_argument('-C', '--disable-playcount-increment', default=False, action='store_true', help='disable the automatic increment of playcounts upon song fetch')
+    parser.add_argument('--keyring-backend', help='name of the keyring backend to use instead of the default one')
+    parser.add_argument('--list-keyring-backends', default=False, action='store_true', help='list the available keyring backends')
+    parser.add_argument('--keyring-service', help='keyring service to use, takes precedence over --password if set')
+    parser.add_argument('--keyring-entry', help='keyring entry to use, required if --keyring-service is used')
 
     config = ConfigParser.SafeConfigParser()
     args = parser.parse_args()
@@ -579,13 +587,9 @@ def getOptions(filename):
     configValues = dict(config.items('dummy'))
 
     # adjust some names in order to make work configparser with argparse
-    if 'device-id' in configValues: configValues['device_id'] = configValues.pop('device-id')
-    if 'list-devices' in configValues: configValues['list_devices'] = configValues.pop('list-devices')
-    if 'disable-all-access' in configValues: configValues['disable_all_access'] = configValues.pop('disable-all-access')
-    if 'disable-version-check' in configValues: configValues['disable_version_check'] = configValues.pop('disable-version-check')
-    if 'extended-m3u' in configValues: configValues['extended_m3u'] = configValues.pop('extended-m3u')
-    if 'shoutcast-metadata' in configValues: configValues['shoutcast_metadata'] = configValues.pop('shoutcast-metadata')
-    if 'disable-playcount-increment' in configValues: configValues['disable_playcount_increment'] = configValues.pop('disable-playcount-increment')
+    for key in configValues.keys():
+        if '-' in key:
+            configValues[key.replace('-', '_')] = configValues.pop(key)
 
     # some defaults
     if 'host' not in configValues: configValues['host']='**auto**'
@@ -645,6 +649,38 @@ def checkLatestVersion():
     except ValueError:
         logger.debug('Error on malformed version data (\'%s\', \'%s\')', latestVersion, programVersion)
 
+def checkKeyringModule():
+    if not 'keyring' in globals():
+        logger.error('Python \'keyring\' module is not available!\n'
+                'Please consult https://pypi.python.org/pypi/keyring#installation-instructions to use keyring feature')
+        sys.exit(1)
+
+def getKeyringPassword():
+    checkKeyringModule()
+    try:
+        if config['keyring_backend']:
+            keyring.set_keyring(keyring.load_keyring(config['keyring_backend']))
+
+        if config['keyring_service'] is None or config['keyring_entry'] is None:
+            logger.error('Please, specify both keyring service and keyring entry in the config file or on the command-line to use keyring feature.')
+            sys.exit(1)
+
+        password = keyring.get_password(config['keyring_service'], config['keyring_entry'])
+        if (password is None):
+            logger.error('No password is stored in entry \'%s\' of service \'%s\'', config['keyring_entry'], config['keyring_service'])
+
+        return password
+    except Exception, e:
+        logger.error('Failed to access keyring: %s', e.message)
+        sys.exit(1)
+
+def listKeyringBackends():
+    checkKeyringModule()
+    logger.info('Available keyring backends:')
+    for backend in keyring.backend.get_all_keyring():
+        logger.info('    %s.%s', type(backend).__module__, type(backend).__name__)
+    sys.exit()
+
 if __name__ == '__main__':
     downloadBlockSize = 5*1024
     defaultNumberTracksStation = 50
@@ -698,6 +734,9 @@ if __name__ == '__main__':
     safeConfig['password'] = '***OMITTED***'   # for debug dump
     logger.debug('configuration used:\n%s\n', pprint.pformat(safeConfig))
 
+    if config['keyring_service'] is not None or config['keyring_entry'] is not None:
+        config['password'] = getKeyringPassword()
+
     if config['email'] is None or config['password'] is None or len(config['email']) == 0 or len(config['password']) == 0:
         logger.error('Please, specify the credentials of your Google account in the config file or on the command-line.')
         sys.exit(1)
@@ -706,6 +745,9 @@ if __name__ == '__main__':
 
     if config['list_devices']:
         listDevices()
+
+    if config['list_keyring_backends']:
+        listKeyringBackends()
 
     if config['host'] == '**auto**':
         config['host'] = autodetectLocalIP()

--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ Here a list of the supported options on the command-line:
 - `--extended-m3u`: enable non-standard extended m3u headers
 - `--shoutcast-metadata`: enable Shoutcast metadata protocol support (disabling IDv3 tags)
 - `--disable-playcount-increment`: disable the automatic increment of playcounts upon song fetch
+- `--keyring-backend`: name of the keyring backend to use instead of the default one
+- `--list-keyring-backends`: list the available keyring backends
+- `--keyring-service`: keyring service to use, takes precedence over `--password` if set
+- `--keyring-entry`: keyring entry to use, required if `--keyring-service` is used
 
 ### Config file
 All the command-line options can be specified in a configuration file. An example of configuration with the strictly required options could look like this:
@@ -194,6 +198,21 @@ All the command-line options can be specified in a configuration file. An exampl
   ```
 
 When the proxy is launched, it searches for a file named `gmusicproxy.cfg` in the XDG-compliant folders like `/home/USER/.config/` or `/etc/xdg/`. It is possible to specify an arbitrary config file on the command-line using the option `--config`.
+
+### Using keyring to store the password
+Password can be retrieved from one of the available keyrings (e.g. KWallet, Freedesktop Secret Service, Windows Credential Vault, Mac OS X Keychain). Use command-line option `--list-keyring-backends` to find out, which keyring backends are supported on your platform.
+If the default keyring backend is not what you want, you can override it using option `--keyring-backend`.
+
+To read the password from the keyring, specify the options `--keyring-service` and `--keyring-entry`. Use the corresponding keyring manager to store the password or find entry name for one of your existing passwords.
+
+E.g. for KWallet, you can list available service names and entries as follows:
+
+  ```bash
+  # list service names
+  kwallet-query -l kdewallet -f ""
+  # list entries of service "Passwords"
+  kwallet-query -l kdewallet -f "Passwords"
+  ```
 
 ### URL-based interface
 The only way to use the service is to query the proxy by means of properly formatted HTTP requests over the configured TCP port. Such URLs can be used directly in music programs or in scripts or in any browser. A URL looks like this: `http://host:port/command?param_1=value&param_2=value`. I don't apply any validation to the submitted values: please, be nice with the proxy and don't exploit it! :)

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,6 @@ setup(
     license=open('LICENSE').read(),
     description='Google Play Music Proxy - "Let\'s stream Google Play Music using any music program"',
     long_description=(open('README.md').read()),
-    install_requires=['gmusicapi==9.0.0', 'netifaces>=0.10.4', 'pyxdg>=0.25', 'eyed3>=0.7.8', 'python-daemon>=2.0.5']
+    install_requires=['gmusicapi==9.0.0', 'netifaces>=0.10.4', 'pyxdg>=0.25', 'eyed3>=0.7.8', 'python-daemon>=2.0.5'],
+    extras_require={'keyring': 'keyring>=10.0'}
 )


### PR DESCRIPTION
Storing unencrypted password in configuration file is insecure. This
commit introduces optional support for 'keyring' module that can be used
to read the password from any available keyring.