### PR TITLE
Cache the end of stream in memory

### DIFF
--- a/GMusicProxy
+++ b/GMusicProxy
@@ -323,19 +323,44 @@ class GetHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             if tagsBin and not do_shoutcast:
                 self.wfile.write(tagsBin)
 
+            # prefill cache
+            cachePrefillSize = 60 * 320/8 * 1024 # 60 seconds at 320 kbit/s
+            maxCacheSize = 180 * 320/8 * 1024 # 180 seconds
+            writtenBytes = 0
             mp3 = opener.open(url)
             block = mp3.read(downloadBlockSize)
             while len(block) > 0:
                 self.wfile.write(block)
+                writtenBytes += len(block)
                 if do_shoutcast:
                     self.wfile.write(self._icy_metadata(
                         tags.album, tags.artist, tags.title))
                 block = mp3.read(downloadBlockSize)
+                if songSize > 0 and writtenBytes > cachePrefillSize and songSize - writtenBytes < maxCacheSize:
+                    break
 
             if not config['disable_playcount_increment']:
                 logger.info('Increment playcount')
                 self._robust_retry(
                     lambda: api.increment_song_playcount(song_id=id))
+
+            if songSize < 0:
+                return
+
+            # consume the end of stream
+            cache = bytearray(0)
+            while len(block) > 0:
+                cache.extend(block)
+                block = mp3.read(downloadBlockSize)
+ 
+            # serve from cache
+            position = 0
+            while position < cacheSize:
+                self.wfile.write(cache[position:position + min(cacheSize - position, downloadBlockSize)])
+                position += downloadBlockSize
+                if do_shoutcast:
+                    self.wfile.write(self._icy_metadata(
+                        tags.album, tags.artist, tags.title))
 
     def _get_all_stations(self, format, separator, onlyUrl):
         logger.info('Getting all stations as plain-text list...' if format ==
@@ -901,7 +926,7 @@ def listKeyringBackends():
     sys.exit()
 
 if __name__ == '__main__':
-    downloadBlockSize = 5 * 1024
+    downloadBlockSize = 16 * 1024
     defaultNumberTracksStation = 50
     defaultNumberTopTracks = 20
     programDescription = 'Google Play Music Proxy'


### PR DESCRIPTION
If the client takes too long (more than about 2-3 minutes) to reach the
end of a long song, the connection is often reset during playback.
This commit prevents this issue by locally caching the content of the
stream in a temporary file.